### PR TITLE
Garbage collection and memory release in load() method

### DIFF
--- a/SOFASonix/SOFASonix.py
+++ b/SOFASonix/SOFASonix.py
@@ -45,6 +45,7 @@ import sqlite3
 import pandas as pd
 import datetime
 import os
+import gc
 from .SOFASonixField import SOFASonixField
 from .SOFASonixError import SOFAError, SOFAFieldError
 
@@ -376,6 +377,7 @@ class SOFASonix(object):
 
     @staticmethod
     def load(file):
+        gc.collect()
         raw = netCDF4.Dataset(file, "r", "NETCDF4")
         # Try to find a convention
         try:

--- a/SOFASonix/SOFASonix.py
+++ b/SOFASonix/SOFASonix.py
@@ -434,6 +434,7 @@ class SOFASonix(object):
 
         # Close h5py file and return SOFASonix object
         raw.close()
+        del raw
         return sofa
 
     def getDim(self, dim):


### PR DESCRIPTION
Program was receiving OOM when loading multiple sofa files due to the persistence of the raw file. Doing a garbage collection prior to the load and deleting the raw H5py file releases the memory between calls to load().